### PR TITLE
Add material-style variants

### DIFF
--- a/Components.md
+++ b/Components.md
@@ -26,3 +26,20 @@ Tooltip – Hover/focus tooltips with theming and smart positioning.
 Progress Indicator – Linear and circular progress components.
 
 Slider – Range input for numeric values.
+
+## Component Variations
+
+The Material design specification defines multiple styles for common widgets. The
+current implementations aim to provide a subset of these patterns:
+
+- **Button** – Supports `variant="text"`, `variant="outlined"`, and `variant="icon"`
+  in addition to the default filled style.
+- **Text Input** – Accepts `variant="filled"` or `variant="outlined"` to switch
+  between Material field styles.
+- **Select** – Includes an optional label slot and basic styling for form
+  controls.
+- **Progress** – Can be used in an indeterminate state via the `indeterminate`
+  attribute.
+
+These variations follow the general look and feel of Material components but are
+implemented in a simplified form compared to the official guidelines.

--- a/components/button.js
+++ b/components/button.js
@@ -15,6 +15,23 @@ export class EUIButton extends HTMLElement {
         color: var(--eui-on-primary, #fff);
         cursor: pointer;
       }
+
+      :host([variant="text"]) button {
+        background: transparent;
+        color: var(--eui-primary, #6200ee);
+      }
+
+      :host([variant="outlined"]) button {
+        background: transparent;
+        color: var(--eui-primary, #6200ee);
+        border: 1px solid var(--eui-primary, #6200ee);
+      }
+
+      :host([variant="icon"]) button {
+        background: transparent;
+        padding: 0.25em;
+        border-radius: 50%;
+      }
     `;
     shadow.appendChild(style);
     shadow.appendChild(button);

--- a/components/progress.js
+++ b/components/progress.js
@@ -6,8 +6,16 @@ export class EUIProgress extends HTMLElement {
     bar.className = 'bar';
     const style = document.createElement('style');
     style.textContent = `
-      :host { display: block; width: 100%; height: 4px; background: #e0e0e0; }
+      :host { display: block; width: 100%; height: 4px; background: #e0e0e0; overflow: hidden; }
       .bar { width: 0; height: 100%; background: var(--eui-primary, #6200ee); transition: width 0.2s; }
+      :host([indeterminate]) .bar {
+        width: 100%;
+        animation: indeterminate 1s infinite linear;
+      }
+      @keyframes indeterminate {
+        0% { transform: translateX(-100%); }
+        100% { transform: translateX(100%); }
+      }
     `;
     shadow.appendChild(style);
     shadow.appendChild(bar);

--- a/components/select.js
+++ b/components/select.js
@@ -2,6 +2,7 @@ export class EUISelect extends HTMLElement {
   constructor() {
     super();
     const shadow = this.attachShadow({ mode: 'open' });
+    const label = document.createElement('label');
     const select = document.createElement('select');
     const slot = document.createElement('slot');
     slot.addEventListener('slotchange', () => {
@@ -10,13 +11,16 @@ export class EUISelect extends HTMLElement {
         select.appendChild(opt.cloneNode(true));
       });
     });
+    label.appendChild(select);
+    label.appendChild(slot);
+
     const style = document.createElement('style');
     style.textContent = `
+      label { display: flex; flex-direction: column; font: inherit; gap: 0.25em; }
       select { font: inherit; padding: 0.5em; border-radius: 4px; }
     `;
     shadow.appendChild(style);
-    shadow.appendChild(select);
-    shadow.appendChild(slot);
+    shadow.appendChild(label);
   }
 
   get value() { return this.shadowRoot.querySelector('select').value; }

--- a/components/text-input.js
+++ b/components/text-input.js
@@ -14,7 +14,23 @@ export class EUITextInput extends HTMLElement {
     style.textContent = `
       :host { display: block; }
       label { display: flex; flex-direction: column; font: inherit; gap: 0.25em; }
-      input { font: inherit; padding: 0.5em; border: 1px solid #ccc; border-radius: 4px; }
+      input {
+        font: inherit;
+        padding: 0.5em;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background: var(--eui-input-bg, white);
+      }
+
+      :host([variant="filled"]) input {
+        background: #f5f5f5;
+        border: none;
+      }
+
+      :host([variant="outlined"]) input {
+        border: 1px solid #ccc;
+        background: var(--eui-input-bg, white);
+      }
     `;
 
     shadow.appendChild(style);


### PR DESCRIPTION
## Summary
- add variant styles to `EUIButton`
- support filled/outlined variants for `EUITextInput`
- add label wrapper for `EUISelect`
- allow indeterminate state for `EUIProgress`
- document available variations for basic components

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a996f8464832eb77af630108c49f0