### PR TITLE
Add navigation links in demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ The library exposes CSS custom properties for colors, spacing and typography. De
 }
 ```
 
+## Demo
+
+Open `index.html` in a browser to see all components in action. Use the color pickers to adjust theme colors.
+
 ## Repository Layout
 
 The `components` directory contains the source for each custom element. You can

--- a/index.html
+++ b/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Elemental UI Demo</title>
+<style>
+  body {
+    font-family: Arial, sans-serif;
+    padding: 1em;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5em;
+  }
+  fieldset {
+    border: 1px solid #ccc;
+    padding: 1em;
+  }
+  .controls {
+    display: flex;
+    gap: 1em;
+  }
+  nav a { text-decoration: none; margin-right: 0.5em; color: var(--eui-primary, #6200ee); }
+  nav a:hover { text-decoration: underline; }
+</style>
+<script type="module" src="./components/index.js"></script>
+</head>
+<body>
+<h1>Elemental UI Components</h1>
+<nav>
+  <a href="#buttons">Buttons</a>
+  <a href="#text-input">Text Input</a>
+  <a href="#select">Select</a>
+  <a href="#checks">Checkbox & Radio</a>
+  <a href="#switch">Switch</a>
+  <a href="#dialog">Dialog</a>
+  <a href="#snackbar">Snackbar</a>
+  <a href="#tabs">Tabs</a>
+  <a href="#card">Card</a>
+  <a href="#tooltip">Tooltip</a>
+  <a href="#progress">Progress</a>
+  <a href="#slider">Slider</a>
+</nav>
+
+<fieldset>
+<legend>Theme</legend>
+<div class="controls">
+<label>Primary Color <input type="color" data-token="eui-primary" value="#6200ee"></label>
+<label>On Primary <input type="color" data-token="eui-on-primary" value="#ffffff"></label>
+<label>Input Background <input type="color" data-token="eui-input-bg" value="#ffffff"></label>
+</div>
+</fieldset>
+
+<section id="buttons">
+  <h2>Buttons</h2>
+  <eui-button id="defaultBtn">Default Button</eui-button>
+  <eui-button variant="text">Text Button</eui-button>
+  <eui-button variant="outlined">Outlined Button</eui-button>
+  <eui-button variant="icon">&#x2764;</eui-button>
+</section>
+
+<section id="text-input">
+  <h2>Text Input</h2>
+  <eui-text-input>
+    <span slot="label">Name</span>
+  </eui-text-input>
+</section>
+
+<section id="select">
+  <h2>Select</h2>
+  <eui-select>
+    <option>Option 1</option>
+    <option>Option 2</option>
+  </eui-select>
+</section>
+
+<section id="checks">
+  <h2>Checkbox & Radio</h2>
+  <eui-checkbox>Accept</eui-checkbox>
+  <br>
+  <eui-radio name="r1">A</eui-radio>
+  <eui-radio name="r1">B</eui-radio>
+</section>
+
+<section id="switch">
+  <h2>Switch</h2>
+  <eui-switch></eui-switch>
+</section>
+
+<section id="dialog">
+  <h2>Dialog</h2>
+  <eui-button onclick="document.getElementById('dlg').open()">Open Dialog</eui-button>
+  <eui-dialog id="dlg">
+    <p>Hello Dialog</p>
+    <eui-button onclick="document.getElementById('dlg').close()">Close</eui-button>
+  </eui-dialog>
+</section>
+
+<section id="snackbar">
+  <h2>Snackbar</h2>
+  <eui-button onclick="document.getElementById('sb').show()">Show Snackbar</eui-button>
+  <eui-snackbar id="sb">Saved!</eui-snackbar>
+</section>
+
+<section id="tabs">
+  <h2>Tabs</h2>
+  <eui-tabs>
+    <span slot="tab">Tab 1</span>
+    <span slot="tab">Tab 2</span>
+    <div>Content 1</div>
+    <div>Content 2</div>
+  </eui-tabs>
+</section>
+
+<section id="card">
+  <h2>Card</h2>
+  <eui-card>
+    <span slot="header">Header</span>
+    <p>Card content</p>
+    <span slot="footer">Footer</span>
+  </eui-card>
+</section>
+
+<section id="tooltip">
+  <h2>Tooltip</h2>
+  <eui-tooltip text="Tooltip text">
+    <eui-button variant="text">Hover me</eui-button>
+  </eui-tooltip>
+</section>
+
+<section id="progress">
+  <h2>Progress</h2>
+  <eui-progress id="prog" value="50"></eui-progress>
+</section>
+
+<section id="slider">
+  <h2>Slider</h2>
+  <eui-slider value="30"></eui-slider>
+</section>
+
+<script>
+  document.querySelectorAll('input[data-token]').forEach(inp => {
+    inp.addEventListener('input', e => {
+      document.documentElement.style.setProperty(`--${e.target.dataset.token}`, e.target.value);
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link component sections within demo page for quick navigation
- add a Demo section to README with a link to `index.html`

## Testing
- `node --version`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686a9d2aa3e8832e942360f572afe341