### PR TITLE
Add tailwind and display calculated colors

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16,11 +16,14 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "autoprefixer": "^10.4.21",
         "eslint": "^9.30.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "postcss": "^8.5.6",
         "sass": "^1.89.2",
+        "tailwindcss": "^4.1.11",
         "vite": "^7.0.3"
       }
     },
@@ -1794,6 +1797,44 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2354,6 +2395,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2700,6 +2755,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2832,6 +2897,13 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -3043,6 +3115,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
+      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/app/package.json
+++ b/app/package.json
@@ -19,11 +19,14 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "autoprefixer": "^10.4.21",
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "postcss": "^8.5.6",
     "sass": "^1.89.2",
+    "tailwindcss": "^4.1.11",
     "vite": "^7.0.3"
   }
 }

--- a/app/postcss.config.js
+++ b/app/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import './App.css'
 
 function hexToHsl(hex) {
@@ -95,6 +95,8 @@ function Section({ id, children }) {
 }
 
 export default function App() {
+  const [tokens, setTokens] = useState({})
+
   useEffect(() => {
     const update = () => {
       const primary = document.getElementById('primaryColor').value
@@ -106,6 +108,25 @@ export default function App() {
       document.documentElement.style.setProperty('--eui-color-background', surface)
       document.documentElement.style.setProperty('--eui-color-on-background', contrast(surface))
       document.documentElement.style.setProperty('--eui-color-on-surface', contrast(surface))
+
+      setTokens({
+        '--eui-color-primary-base': primary,
+        '--eui-color-primary-hover': darken(primary, 0.1),
+        '--eui-color-primary-active': darken(primary, 0.2),
+        '--eui-color-primary-container': lighten(primary, 0.4),
+        '--eui-color-primary-disabled': lighten(primary, 0.5),
+        '--eui-color-on-primary': contrast(primary),
+        '--eui-color-secondary-base': secondary,
+        '--eui-color-secondary-hover': darken(secondary, 0.1),
+        '--eui-color-secondary-active': darken(secondary, 0.2),
+        '--eui-color-secondary-container': lighten(secondary, 0.4),
+        '--eui-color-secondary-disabled': lighten(secondary, 0.5),
+        '--eui-color-on-secondary': contrast(secondary),
+        '--eui-color-surface': surface,
+        '--eui-color-background': surface,
+        '--eui-color-on-background': contrast(surface),
+        '--eui-color-on-surface': contrast(surface),
+      })
     }
 
     update()
@@ -116,25 +137,33 @@ export default function App() {
   }, [])
 
   return (
-    <div className="demo-layout">
-      <aside className="theme-panel">
+    <div className="demo-layout flex items-start gap-8">
+      <aside className="theme-panel w-56">
         <fieldset>
           <legend>Theme</legend>
-          <div className="controls">
-            <label>
-              Primary
+          <div className="flex flex-col gap-2">
+            <label className="flex items-center justify-between gap-2">
+              <span>Primary</span>
               <input id="primaryColor" data-color="primary" type="color" defaultValue="#6200ee" />
             </label>
-            <label>
-              Secondary
+            <label className="flex items-center justify-between gap-2">
+              <span>Secondary</span>
               <input id="secondaryColor" data-color="secondary" type="color" defaultValue="#018786" />
             </label>
-            <label>
-              Surface
+            <label className="flex items-center justify-between gap-2">
+              <span>Surface</span>
               <input id="surfaceColor" data-color="surface" type="color" defaultValue="#ffffff" />
             </label>
           </div>
         </fieldset>
+        <div className="mt-4 space-y-1 text-xs">
+          {Object.entries(tokens).map(([name, value]) => (
+            <div key={name} className="flex items-center gap-2">
+              <span className="inline-block w-4 h-4 rounded" style={{ backgroundColor: value }} />
+              <code>{`${name}: ${value}`}</code>
+            </div>
+          ))}
+        </div>
       </aside>
 
       <main className="demo-content">

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 body {
   font-family: Arial, sans-serif;
   padding: 0;
@@ -9,10 +13,7 @@ fieldset {
   padding: 1em;
 }
 
-.controls {
-  display: flex;
-  gap: 1em;
-}
+
 
 nav a {
   text-decoration: none;

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- use Tailwind CSS in the React demo app
- show calculated theme colors
- adjust layout so theme controls don't overlap

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ea66c3914832eab1ef46c9822203e