### PR TITLE
Update theme outline handling

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -87,6 +87,8 @@ function applyTone(prefix, base) {
   const disabledTone = lighten(base, 0.5)
   const on = contrast(base)
 
+  root.style.setProperty(`--eui-color-${prefix}-outline`, base)
+
   root.style.setProperty(`--eui-color-${prefix}-base`, base)
   root.style.setProperty(`--eui-color-${prefix}-hover`, hover)
   root.style.setProperty(`--eui-color-${prefix}-active`, active)
@@ -98,6 +100,7 @@ function applyTone(prefix, base) {
   setInputValue(`${prefix}ActiveColor`, active)
   setInputValue(`${prefix}ContainerColor`, container)
   setInputValue(`${prefix}DisabledColor`, disabledTone)
+  setInputValue(`${prefix}OutlineColor`, base)
   setInputValue(`on${prefix.charAt(0).toUpperCase() + prefix.slice(1)}Color`, on)
 }
 
@@ -120,12 +123,9 @@ export default function App() {
     'surface-variant': '#e7e0ec',
     'on-background': '#1c1b1f',
     'on-surface': '#1c1b1f',
-    outline: 'rgba(0, 0, 0, 0.12)',
     error: '#b00020',
     warning: '#fbc02d',
     success: '#388e3c',
-    disabled: 'rgba(0, 0, 0, 0.38)',
-    'on-disabled': 'rgba(0, 0, 0, 0.12)',
     'elevation-0': '#ffffff',
     'elevation-1': '#f7f2fa',
     'elevation-2': '#eee7f4',
@@ -142,8 +142,6 @@ export default function App() {
       const warning = document.getElementById('warningColor').value
       const success = document.getElementById('successColor').value
       const background = document.getElementById('backgroundColor').value
-      const outline = document.getElementById('outlineColor').value
-      const disabled = document.getElementById('disabledColor').value
       const elevation0 = document.getElementById('elevation0Color').value
       const elevation1 = document.getElementById('elevation1Color').value
       const elevation2 = document.getElementById('elevation2Color').value
@@ -151,12 +149,10 @@ export default function App() {
       const surfaceVariant = lighten(surface, 0.1)
       const onSurface = contrast(surface)
       const onBackground = contrast(background)
-      const onDisabled = contrast(disabled)
 
       setInputValue('surfaceVariantColor', surfaceVariant)
       setInputValue('onSurfaceColor', onSurface)
       setInputValue('onBackgroundColor', onBackground)
-      setInputValue('onDisabledColor', onDisabled)
 
       applyTone('primary', primary)
       applyTone('secondary', secondary)
@@ -169,9 +165,6 @@ export default function App() {
       document.documentElement.style.setProperty('--eui-color-on-background', onBackground)
       document.documentElement.style.setProperty('--eui-color-surface-variant', surfaceVariant)
       document.documentElement.style.setProperty('--eui-color-on-surface', onSurface)
-      document.documentElement.style.setProperty('--eui-color-outline', outline)
-      document.documentElement.style.setProperty('--eui-color-disabled', disabled)
-      document.documentElement.style.setProperty('--eui-color-on-disabled', onDisabled)
       document.documentElement.style.setProperty('--eui-color-elevation-0', elevation0)
       document.documentElement.style.setProperty('--eui-color-elevation-1', elevation1)
       document.documentElement.style.setProperty('--eui-color-elevation-2', elevation2)
@@ -182,6 +175,7 @@ export default function App() {
         '--eui-color-primary-active': darken(primary, 0.2),
         '--eui-color-primary-container': lighten(primary, 0.4),
         '--eui-color-primary-disabled': lighten(primary, 0.5),
+        '--eui-color-primary-outline': primary,
         '--eui-color-on-primary': contrast(primary),
 
         '--eui-color-secondary-base': secondary,
@@ -189,6 +183,7 @@ export default function App() {
         '--eui-color-secondary-active': darken(secondary, 0.2),
         '--eui-color-secondary-container': lighten(secondary, 0.4),
         '--eui-color-secondary-disabled': lighten(secondary, 0.5),
+        '--eui-color-secondary-outline': secondary,
         '--eui-color-on-secondary': contrast(secondary),
 
         '--eui-color-error-base': error,
@@ -196,6 +191,7 @@ export default function App() {
         '--eui-color-error-active': darken(error, 0.2),
         '--eui-color-error-container': lighten(error, 0.4),
         '--eui-color-error-disabled': lighten(error, 0.5),
+        '--eui-color-error-outline': error,
         '--eui-color-on-error': contrast(error),
 
         '--eui-color-warning-base': warning,
@@ -203,6 +199,7 @@ export default function App() {
         '--eui-color-warning-active': darken(warning, 0.2),
         '--eui-color-warning-container': lighten(warning, 0.4),
         '--eui-color-warning-disabled': lighten(warning, 0.5),
+        '--eui-color-warning-outline': warning,
         '--eui-color-on-warning': contrast(warning),
 
         '--eui-color-success-base': success,
@@ -210,6 +207,7 @@ export default function App() {
         '--eui-color-success-active': darken(success, 0.2),
         '--eui-color-success-container': lighten(success, 0.4),
         '--eui-color-success-disabled': lighten(success, 0.5),
+        '--eui-color-success-outline': success,
         '--eui-color-on-success': contrast(success),
 
         '--eui-color-surface': surface,
@@ -217,9 +215,6 @@ export default function App() {
         '--eui-color-background': background,
         '--eui-color-on-background': onBackground,
         '--eui-color-on-surface': onSurface,
-        '--eui-color-outline': outline,
-        '--eui-color-disabled': disabled,
-        '--eui-color-on-disabled': onDisabled,
         '--eui-color-elevation-0': elevation0,
         '--eui-color-elevation-1': elevation1,
         '--eui-color-elevation-2': elevation2,
@@ -260,6 +255,10 @@ export default function App() {
               <input id="primaryDisabledColor" data-color="primary-disabled" type="color" defaultValue={lighten(DEFAULTS.primary, 0.5)} disabled />
             </label>
             <label className="flex items-center justify-between gap-2 pl-4">
+              <span>Outline</span>
+              <input id="primaryOutlineColor" data-color="primary-outline" type="color" defaultValue={DEFAULTS.primary} disabled />
+            </label>
+            <label className="flex items-center justify-between gap-2 pl-4">
               <span>On Primary</span>
               <input id="onPrimaryColor" data-color="on-primary" type="color" defaultValue={contrast(DEFAULTS.primary)} disabled />
             </label>
@@ -283,6 +282,10 @@ export default function App() {
             <label className="flex items-center justify-between gap-2 pl-4">
               <span>Disabled</span>
               <input id="secondaryDisabledColor" data-color="secondary-disabled" type="color" defaultValue={lighten(DEFAULTS.secondary, 0.5)} disabled />
+            </label>
+            <label className="flex items-center justify-between gap-2 pl-4">
+              <span>Outline</span>
+              <input id="secondaryOutlineColor" data-color="secondary-outline" type="color" defaultValue={DEFAULTS.secondary} disabled />
             </label>
             <label className="flex items-center justify-between gap-2 pl-4">
               <span>On Secondary</span>
@@ -312,10 +315,6 @@ export default function App() {
             </label>
             <hr className="my-2 border-t" />
             <label className="flex items-center justify-between gap-2">
-              <span>Outline</span>
-              <input id="outlineColor" data-color="outline" type="color" defaultValue={DEFAULTS.outline} disabled />
-            </label>
-            <label className="flex items-center justify-between gap-2">
               <span>Error</span>
               <input id="errorColor" data-color="error" type="color" defaultValue={DEFAULTS.error} disabled />
             </label>
@@ -334,6 +333,10 @@ export default function App() {
             <label className="flex items-center justify-between gap-2 pl-4">
               <span>Disabled</span>
               <input id="errorDisabledColor" data-color="error-disabled" type="color" defaultValue={lighten(DEFAULTS.error, 0.5)} disabled />
+            </label>
+            <label className="flex items-center justify-between gap-2 pl-4">
+              <span>Outline</span>
+              <input id="errorOutlineColor" data-color="error-outline" type="color" defaultValue={DEFAULTS.error} disabled />
             </label>
             <label className="flex items-center justify-between gap-2 pl-4">
               <span>On Error</span>
@@ -362,6 +365,10 @@ export default function App() {
               <input id="warningDisabledColor" data-color="warning-disabled" type="color" defaultValue={lighten(DEFAULTS.warning, 0.5)} disabled />
             </label>
             <label className="flex items-center justify-between gap-2 pl-4">
+              <span>Outline</span>
+              <input id="warningOutlineColor" data-color="warning-outline" type="color" defaultValue={DEFAULTS.warning} disabled />
+            </label>
+            <label className="flex items-center justify-between gap-2 pl-4">
               <span>On Warning</span>
               <input id="onWarningColor" data-color="on-warning" type="color" defaultValue={contrast(DEFAULTS.warning)} disabled />
             </label>
@@ -388,17 +395,12 @@ export default function App() {
               <input id="successDisabledColor" data-color="success-disabled" type="color" defaultValue={lighten(DEFAULTS.success, 0.5)} disabled />
             </label>
             <label className="flex items-center justify-between gap-2 pl-4">
-              <span>On Success</span>
-              <input id="onSuccessColor" data-color="on-success" type="color" defaultValue={contrast(DEFAULTS.success)} disabled />
-            </label>
-            <hr className="my-2 border-t" />
-            <label className="flex items-center justify-between gap-2">
-              <span>Disabled</span>
-              <input id="disabledColor" data-color="disabled" type="color" defaultValue={DEFAULTS.disabled} disabled />
+              <span>Outline</span>
+              <input id="successOutlineColor" data-color="success-outline" type="color" defaultValue={DEFAULTS.success} disabled />
             </label>
             <label className="flex items-center justify-between gap-2 pl-4">
-              <span>On Disabled</span>
-              <input id="onDisabledColor" data-color="on-disabled" type="color" defaultValue={contrast(DEFAULTS.disabled)} disabled />
+              <span>On Success</span>
+              <input id="onSuccessColor" data-color="on-success" type="color" defaultValue={contrast(DEFAULTS.success)} disabled />
             </label>
             <hr className="my-2 border-t" />
             <label className="flex items-center justify-between gap-2">

--- a/components/basic/button.js
+++ b/components/basic/button.js
@@ -28,7 +28,8 @@ template.innerHTML = `
       cursor: default;
       pointer-events: none;
       background: var(--eui-color-primary-disabled, #ccc);
-      color: var(--eui-color-on-disabled, #666);
+      color: var(--eui-color-on-primary, #666);
+      opacity: 0.38;
       box-shadow: none;
     }
     :host([variant="contained"]) button {
@@ -44,7 +45,7 @@ template.innerHTML = `
       background: var(--eui-color-primary-active, #30009c);
     }
     :host([variant="outlined"]) button {
-      border: 1px solid var(--eui-color-outline, #ccc);
+      border: 1px solid var(--eui-color-primary-outline, #ccc);
     }
     :host([variant="text"]) button {
       color: var(--eui-color-primary-base, #6200ee);

--- a/components/basic/button_requirements.md
+++ b/components/basic/button_requirements.md
@@ -37,14 +37,13 @@ A flexible, accessible button component that supports multiple visual variants, 
 ```
 --eui-color-primary-base  
 --eui-color-primary-hover  
---eui-color-primary-active  
---eui-color-primary-disabled  
---eui-color-on-primary  
---eui-color-outline  
---eui-color-disabled  
---eui-outline-focus  
---eui-shadow-1  
---eui-shadow-2  
+--eui-color-primary-active
+--eui-color-primary-disabled
+--eui-color-on-primary
+--eui-color-primary-outline
+--eui-outline-focus
+--eui-shadow-1
+--eui-shadow-2
 ```
 
 ---

--- a/theme/AGENTS.md
+++ b/theme/AGENTS.md
@@ -23,18 +23,20 @@ Used for main and accent actions.
 
 - `--eui-color-primary-base`: Default primary color  
 - `--eui-color-primary-hover`: On hover state  
-- `--eui-color-primary-active`: On active (pressed) state  
-- `--eui-color-primary-container`: For filled surfaces (e.g. chips, cards)  
-- `--eui-color-primary-disabled`: Muted state of primary  
+- `--eui-color-primary-active`: On active (pressed) state
+- `--eui-color-primary-container`: For filled surfaces (e.g. chips, cards)
+- `--eui-color-primary-disabled`: Muted state of primary
+- `--eui-color-primary-outline`: Border tone matching base
 - `--eui-color-on-primary`: Foreground content on primary
 
 ### Secondary (same structure as primary)
 
 - `--eui-color-secondary-base`  
 - `--eui-color-secondary-hover`  
-- `--eui-color-secondary-active`  
-- `--eui-color-secondary-container`  
-- `--eui-color-secondary-disabled`  
+- `--eui-color-secondary-active`
+- `--eui-color-secondary-container`
+- `--eui-color-secondary-disabled`
+- `--eui-color-secondary-outline`
 - `--eui-color-on-secondary`
 
 **Example Usage**:
@@ -64,8 +66,9 @@ Each status includes the following variants:
 - `base`: Default color  
 - `hover`: On hover  
 - `active`: On press  
-- `container`: For filled usage (e.g. alerts)  
+- `container`: For filled usage (e.g. alerts)
 - `on-*`: Foreground on that background
+- `outline`: Border tone matching base
 
 ### Example Tokens
 
@@ -75,17 +78,13 @@ Each status includes the following variants:
 
 ---
 
-## 🚫 Disabled & Outline
+## 🔳 Focus Outline
 
-- `--eui-color-disabled`: Muted background (e.g. button)  
-- `--eui-color-on-disabled`: Foreground on disabled  
-- `--eui-color-outline`: Border color (e.g. outlined button)  
 - `--eui-outline-focus`: Focus ring (usually 2px solid)
 
 **Example Usage**:
 ```css
 outline: var(--eui-outline-focus);
-color: var(--eui-color-on-disabled);
 ```
 
 ---

--- a/theme/theme.scss
+++ b/theme/theme.scss
@@ -5,6 +5,7 @@
   --eui-color-primary-active: #30009c;
   --eui-color-primary-disabled: #cbb7f0;
   --eui-color-primary-container: #e8def8;
+  --eui-color-primary-outline: var(--eui-color-primary-base);
   --eui-color-on-primary: #ffffff;
 
   // SECONDARY
@@ -12,6 +13,7 @@
   --eui-color-secondary-hover: #016d6c;
   --eui-color-secondary-active: #014a49;
   --eui-color-secondary-container: #c8f8f6;
+  --eui-color-secondary-outline: var(--eui-color-secondary-base);
   --eui-color-on-secondary: #ffffff;
 
   // BACKGROUND & SURFACE
@@ -22,14 +24,13 @@
   --eui-color-surface-variant: #e7e0ec;
   --eui-color-on-surface: #1c1b1f;
 
-  // OUTLINE / BORDER
-  --eui-color-outline: rgba(0, 0, 0, 0.12);
 
   // ERROR
   --eui-color-error-base: #b00020;
   --eui-color-error-hover: #8c001a;
   --eui-color-error-active: #660015;
   --eui-color-error-container: #fcd8df;
+  --eui-color-error-outline: var(--eui-color-error-base);
   --eui-color-on-error: #ffffff;
 
   // SUCCESS
@@ -37,6 +38,7 @@
   --eui-color-success-hover: #2e7d32;
   --eui-color-success-active: #1b5e20;
   --eui-color-success-container: #c8e6c9;
+  --eui-color-success-outline: var(--eui-color-success-base);
   --eui-color-on-success: #ffffff;
 
   // WARNING
@@ -44,11 +46,9 @@
   --eui-color-warning-hover: #f9a825;
   --eui-color-warning-active: #f57f17;
   --eui-color-warning-container: #fff8e1;
+  --eui-color-warning-outline: var(--eui-color-warning-base);
   --eui-color-on-warning: #000000;
 
-  // DISABLED
-  --eui-color-disabled: rgba(0, 0, 0, 0.38);
-  --eui-color-on-disabled: rgba(0, 0, 0, 0.12);
 
   // SHADOWS
   --eui-shadow-1: 0 1px 3px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Summary
- add `outline` tone for all roles in theme
- drop global outline and disabled color tokens
- update docs and requirements
- tweak button styles and demo App
- include outline inputs in theme editor

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f66cce9f8832e967538c9100cb4b2