### PR TITLE
Fix center box layout

### DIFF
--- a/components/container/center-box.js
+++ b/components/container/center-box.js
@@ -3,6 +3,9 @@ import { EUIContainerElement } from './eui-container.js';
 export class EUICenterBox extends EUIContainerElement {
   constructor() {
     super('column');
+    this.style.height = '100%';
+    this.style.width = '100%';
+    this.style.boxSizing = 'border-box';
   }
 
   get justifyContent() {


### PR DESCRIPTION
## Summary
- extend `<eui-center-box>` so it expands to the full size of its parent
- vertically centers by default

## Testing
- `npm run lint --prefix app` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f9765a924832e9bfa5a5c5cf637a1