### PR TITLE
Add Grid Box component with demo example

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,6 +13,7 @@
     <script type="module" src="/components/container/vbox.js"></script>
     <script type="module" src="/components/container/hbox.js"></script>
     <script type="module" src="/components/container/center-box.js"></script>
+    <script type="module" src="/components/container/grid-box.js"></script>
 
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -455,6 +455,23 @@ export default function App() {
           </div>
         </Section>
 
+        <Section id="grid-box">
+          <eui-grid
+            columns="auto auto auto"
+            rows="auto auto"
+            areas="'a b c' 'd e f'"
+            gap="sm"
+            padding="sm"
+          >
+            <div className="demo-box" slot="a">A</div>
+            <div className="demo-box" slot="b">B</div>
+            <div className="demo-box" slot="c">C</div>
+            <div className="demo-box" slot="d">D</div>
+            <div className="demo-box" slot="e">E</div>
+            <div className="demo-box" slot="f">F</div>
+          </eui-grid>
+        </Section>
+
         <Section id="buttons">
           <eui-button id="defaultBtn" label="Default Button"></eui-button>
           <eui-button variant="contained" label="Contained Button"></eui-button>
@@ -466,6 +483,7 @@ export default function App() {
         <a href="#vbox">VBox</a>
         <a href="#hbox">HBox</a>
         <a href="#center-box">Center Box</a>
+        <a href="#grid-box">Grid Box</a>
         <a href="#buttons">Buttons</a>
       </nav>
     </div>

--- a/components/container/grid-box.js
+++ b/components/container/grid-box.js
@@ -1,0 +1,103 @@
+const GAP_MAP = {
+  xs: 'var(--eui-spacing-xs, 4px)',
+  sm: 'var(--eui-spacing-sm, 8px)',
+  md: 'var(--eui-spacing-md, 16px)',
+  lg: 'var(--eui-spacing-lg, 24px)',
+  xl: 'var(--eui-spacing-xl, 32px)',
+};
+
+const template = document.createElement('template');
+template.innerHTML = `
+  <style>
+    :host {
+      display: grid;
+      grid-template-columns: var(--_columns, 1fr);
+      grid-template-rows: var(--_rows, auto);
+      grid-template-areas: var(--_areas);
+      gap: var(--_gap, 16px);
+      padding: var(--_padding, 16px);
+      box-sizing: border-box;
+    }
+    ::slotted([slot]) {
+      grid-area: attr(slot);
+    }
+  </style>
+  <slot></slot>
+`;
+
+export class EUIGrid extends HTMLElement {
+  static get observedAttributes() {
+    return ['columns', 'rows', 'areas', 'gap', 'padding'];
+  }
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+    this._shadow.appendChild(template.content.cloneNode(true));
+  }
+
+  connectedCallback() {
+    this._applyStyles();
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (oldValue === newValue) return;
+    this._applyStyles();
+  }
+
+  get columns() {
+    return this.getAttribute('columns') || '1fr';
+  }
+  set columns(val) {
+    if (val === null) this.removeAttribute('columns');
+    else this.setAttribute('columns', val);
+  }
+
+  get rows() {
+    return this.getAttribute('rows') || 'auto';
+  }
+  set rows(val) {
+    if (val === null) this.removeAttribute('rows');
+    else this.setAttribute('rows', val);
+  }
+
+  get areas() {
+    return this.getAttribute('areas') || '';
+  }
+  set areas(val) {
+    if (val === null) this.removeAttribute('areas');
+    else this.setAttribute('areas', val);
+  }
+
+  get gap() {
+    return this.getAttribute('gap') || 'md';
+  }
+  set gap(val) {
+    if (val === null) this.removeAttribute('gap');
+    else this.setAttribute('gap', val);
+  }
+
+  get padding() {
+    return this.getAttribute('padding');
+  }
+  set padding(val) {
+    if (val === null) this.removeAttribute('padding');
+    else this.setAttribute('padding', val);
+  }
+
+  _applyStyles() {
+    const gapKey = this.gap;
+    const gapVal = GAP_MAP[gapKey] || gapKey;
+    this.style.setProperty('--_gap', gapVal);
+
+    const padKey = this.padding ?? gapKey;
+    const padVal = GAP_MAP[padKey] || padKey;
+    this.style.setProperty('--_padding', padVal);
+
+    this.style.setProperty('--_columns', this.columns);
+    this.style.setProperty('--_rows', this.rows);
+    this.style.setProperty('--_areas', this.areas);
+  }
+}
+
+customElements.define('eui-grid', EUIGrid);

--- a/components/index.js
+++ b/components/index.js
@@ -2,3 +2,4 @@ export * from './basic/button.js';
 export * from './container/vbox.js';
 export * from './container/hbox.js';
 export * from './container/center-box.js';
+export * from './container/grid-box.js';


### PR DESCRIPTION
## Summary
- implement `<eui-grid>` component for grid layouts
- export grid box in component index
- add example section in React demo
- load grid-box in demo HTML

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f9a998620832e955a187793387a20